### PR TITLE
Devcontainer для работы c VSCode XP

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 			}
 		}
 	},
-	"postCreateCommand": "wget $(curl -s https://api.github.com/repos/vxcontrol/xp-kbt/releases/latest | jq -r '.assets[] | select(.name | contains(\"debian\")).browser_download_url') -O /tmp/xp-kbt.zip && unzip /tmp/xp-kbt.zip -d /tmp/xp-kbt"
+	"postCreateCommand": "wget $(curl -s https://api.github.com/repos/vxcontrol/xp-kbt/releases/latest | jq -r '.assets[] | select(.name | contains(\"debian\")).browser_download_url') -O /tmp/xp-kbt.zip && unzip -o /tmp/xp-kbt.zip -d /tmp/xp-kbt"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,16 +14,13 @@
 			}
 		}
 	},
-	"postCreateCommand": "wget https://github.com/vxcontrol/xp-kbt/releases/download/26.2.4391/kbt.26.2.4391-debian-10.zip -O /tmp/xp-kbt.zip && unzip /tmp/xp-kbt.zip -d /tmp/xp-kbt"
+	"postCreateCommand": "wget $(curl -s https://api.github.com/repos/vxcontrol/xp-kbt/releases/latest | jq -r '.assets[] | select(.name | contains(\"debian\")).browser_download_url') -O /tmp/xp-kbt.zip && unzip /tmp/xp-kbt.zip -d /tmp/xp-kbt"
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
-	// Configure tool-specific properties.
-	// "customizations": {},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"SecurityExpertsCommunity.xp"
+			],
+			"settings": {
+				"xpConfig.kbtBaseDirectory": "/tmp/xp-kbt"
+			}
+		}
+	},
+	"postCreateCommand": "wget https://github.com/vxcontrol/xp-kbt/releases/download/26.2.4391/kbt.26.2.4391-debian-10.zip -O /tmp/xp-kbt.zip && unzip /tmp/xp-kbt.zip -d /tmp/xp-kbt"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
PR добавляет конфигурацию devcontainer для автоматического развертывания расширения VSCode XP и скачивания xp-kbt при инциализации GitHub Codespaces.
Как пользоваться:
1. В своем форке в GitHub в меню `Code` пользователь создает Codespace  
<img width="461" alt="image" src="https://github.com/Security-Experts-Community/open-xp-rules/assets/20799025/0cb4ed43-e2a8-4546-9ce1-ae0ac879423b"> 

2. Создается Codespace - облачная версия VSCode на ресурсах GitHub, туда автоматически добавляется и настраивается расширение VSCode XP, загружается последняя версия xp-kbt
3. После всех загрузок пользователь может работать с git-репозиторием как обычно: создавать правила, коммить, пушить и тд без необходимости ручной настройки. 

Выглядит это вот так:
<img width="1552" alt="image" src="https://github.com/Security-Experts-Community/open-xp-rules/assets/20799025/9882ca52-bd14-40ca-ae1d-19d097fc5ecc">

